### PR TITLE
Settings page import error

### DIFF
--- a/src/lib/Common/GridLayout.svelte
+++ b/src/lib/Common/GridLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Navbar from '$components/navbar/Navbar.svelte';
-	import LastColumnRectangle from '$icons/lastColumnRectangle.svelte';
+	import LastColumnRectangle from '$icons/LastColumnRectangle.svelte';
 	import { slide } from 'svelte/transition';
 </script>
 

--- a/src/lib/Settings/ChangeThemeBar.svelte
+++ b/src/lib/Settings/ChangeThemeBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import ThemeSwitch from '$lib/AccountSettings/ThemeSwitch.svelte';
+	import ThemeSwitch from '$lib/Settings/ThemeSwitch.svelte';
 </script>
 
 <div class="theme-bar">

--- a/src/routes/settings.svelte
+++ b/src/routes/settings.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import AvatarCard from '$lib/AccountSettings/AvatarCard.svelte';
+	import AvatarCard from '$lib/Settings/AvatarCard.svelte';
 	import ChooseFileButton from '$lib/Common/ChooseFileButton.svelte';
-	import ChangeThemeBar from '$lib/AccountSettings/ChangeThemeBar.svelte';
-	import InfoInput from '$lib/AccountSettings/InfoInput.svelte';
+	import ChangeThemeBar from '$lib/Settings/ChangeThemeBar.svelte';
+	import InfoInput from '$lib/Settings/InfoInput.svelte';
 	import SelectItems from '$components/navbar/SelectItems.svelte';
 	import GridLayout from '$lib/Common/GridLayout.svelte';
 


### PR DESCRIPTION
Error caused by importing `$icons/lastColumnRectangle.svelte` instead of `$icons/LastColumnRectangle.svelte` inside GridLayout, and by importing from `$lib/AccountSettings` instead of `$lib/Settings` (Renamed in 3b1d3a84076bb4f8a69aa3143ce3f423c121b1d2)